### PR TITLE
Small fix to avoid the first page of results from looping endlessly when scrolling.

### DIFF
--- a/The Internet Archive Companion/IAJsonDataService.m
+++ b/The Internet Archive Companion/IAJsonDataService.m
@@ -219,16 +219,10 @@
 
 - (NSString *) docsUrlStringWithTest:(NSString *)test withStart:(NSString *)start{
     testUrl = test;
-    return [NSString stringWithFormat:@"%@&start=%@", testUrl, start];
+    int pageNumber = (start.intValue / 50) + 1;
+    NSString *pageNumberStr = [NSString stringWithFormat:@"%d", pageNumber];
+    return [NSString stringWithFormat:@"%@&page=%@", testUrl, pageNumberStr];
 }
-
-
-
-
-
-
-
-
 
 - (void) packageJsonResponeDictionary:(NSDictionary *)jsonResponse{
     


### PR DESCRIPTION
Hello there, I know this project has been inactive for a few years, but it's quite useful for users of the Internet Archive and I'd like to see it back in development.

This is why I took a look at an issue where when you scroll in any results page, it keeps loading the first page endlessly instead of loading a new one. It was a simple enough fix, since the Archive's API seems to have changed the syntax for paging, so setting page numbers instead of a result offset did the trick.

Please let me know if you're still interested on keeping this project alive, and of course about any issues you may find with this PR.

Cheers!